### PR TITLE
Added node_modules to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+/node_modules


### PR DESCRIPTION
This pull request updates the .gitignore file to include node_modules, ensuring that the directory is not tracked by Git. This change is essential for reducing repository size, improving performance, and avoiding conflicts with local dependencies.